### PR TITLE
Add CSS variable label-white-space

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ There are following CSS Custom Properties are available:
 | `--label-text-color`           | `inherit`                                                 |
 | `--label-font-size`            | `10px`                                                    |
 | `--label-font-weight`          | `500`                                                     |
+| `--label-white-space`          | `nowrap`                                                  |
 | `--legend-text-color`          | `inherit`                                                 |
 | `--legend-disabled-text-color` | `#ccc`                                                    |
 | `--legend-font-size`           | `14px`                                                    |

--- a/src/codersrank-skills-chart.scss
+++ b/src/codersrank-skills-chart.scss
@@ -7,6 +7,7 @@
   --label-text-color: inherit;
   --label-font-size: 10px;
   --label-font-weight: 500;
+  --label-white-space: nowrap;
   --legend-text-color: inherit;
   --legend-disabled-text-color: #ccc;
   --legend-font-size: 14px;
@@ -80,7 +81,7 @@
       display: flex;
       align-items: flex-start;
       justify-content: center;
-      white-space: nowrap;
+      white-space: var(--label-white-space);
       &:first-child {
         justify-content: flex-start;
       }


### PR DESCRIPTION
This pull request aims to add a new CSS variable to the widget.
This CSS variable allows the user to change the way labels are wrapped.
So users may change this when labels are overlapping on smaller screens.

For more info see issue #7.