### PR TITLE
Add sort-by-score attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Widget supports following properties as HTML element attributes:
 | `show-other-skills` | `boolean` | `false` | Group skills not specified in `skills` property under the "Other" chart area                                                                            |
 | `max-labels`        | `number`  | `8`     | Maximum amount of labels (dates) to be displayed (dates)                                                                                                |
 | `branding`          | `boolean` | `true`  | Displays "Powered by CodersRank" link                                                                                                                   |
+| `sort-by-score`     | `boolean` | `false` | Sorts labels by score if true or alphabetically                                                                                                         |
 
 For example, to enable labels, legend and tooltip:
 

--- a/api/index.js
+++ b/api/index.js
@@ -292,7 +292,12 @@ const getColor = (language) => {
     : stringToColor(language, false);
 };
 
-const getChartData = (data = [], displaySkills = [], showOtherSkills = false) => {
+const getChartData = (
+  data = [],
+  displaySkills = [],
+  showOtherSkills = false,
+  sortByScore = false,
+) => {
   const scoresData = [...data];
 
   const languagesList = [];
@@ -313,16 +318,19 @@ const getChartData = (data = [], displaySkills = [], showOtherSkills = false) =>
   const labels = scoresData.map((score) => score.date);
   const datasets = languagesList.map((language) => {
     const values = [];
+    let maxScore = 0;
     scoresData.forEach((score) => {
       const languageData = score.languages.filter(
         (langData) => langData.language === language,
       )[0];
+      if (languageData && languageData.score > maxScore) maxScore = languageData.score;
       values.push(languageData ? languageData.score : 0);
     });
     return {
       label: language,
       color: getColor(language),
       values,
+      maxScore,
     };
   });
 
@@ -345,10 +353,17 @@ const getChartData = (data = [], displaySkills = [], showOtherSkills = false) =>
     };
   }
 
-  datasets.sort((a, b) => {
-    if (b.label === 'Other') return -1;
-    return a.label > b.label ? 1 : -1;
-  });
+  if (sortByScore) {
+    datasets.sort((a, b) => {
+      if (b.label === 'Other') return -1;
+      return a.maxScore > b.maxScore ? 1 : -1;
+    });
+  } else {
+    datasets.sort((a, b) => {
+      if (b.label === 'Other') return -1;
+      return a.label > b.label ? 1 : -1;
+    });
+  }
 
   if (otherDataset) {
     datasets.push(otherDataset);
@@ -525,6 +540,13 @@ module.exports = async (context, req) => {
       .map((s) => s.trim())
       .filter((s) => !!s);
   }
+
+  let sortByScore = false;
+  if (req.query['sort-by-score']) {
+    sortByScore = req.query['sort-by-score'] || false;
+    if (sortByScore === 'true') sortByScore = true;
+  }
+
   let width = 640;
   let height = 320;
   if (req.query.width) {
@@ -552,7 +574,7 @@ module.exports = async (context, req) => {
     padding = parseInt(req.query.padding, 10);
   }
   const data = await fetchData(req.query.username);
-  const chartData = getChartData(data.scores, skills, showOtherSkills);
+  const chartData = getChartData(data.scores, skills, showOtherSkills, sortByScore);
   const svg = renderChart({
     data: chartData,
     labels: true,

--- a/api/index.js
+++ b/api/index.js
@@ -356,7 +356,7 @@ const getChartData = (
   if (sortByScore) {
     datasets.sort((a, b) => {
       if (b.label === 'Other') return -1;
-      return a.maxScore > b.maxScore ? 1 : -1;
+      return a.maxScore > b.maxScore ? -1 : 1;
     });
   } else {
     datasets.sort((a, b) => {

--- a/package/README.md
+++ b/package/README.md
@@ -189,6 +189,7 @@ It accepts query parameters:
 | `show-other-skills` | `boolean` | `false` | Group skills not specified in `skills` property under the "Other" chart area                      |
 | `bg`                | `string`  | `#fff`  | Chart background image                                                                            |
 | `padding`           | `number`  | `0`     | Image content padding                                                                             |
+| `sort-by-score`     | `boolean` | `false` | Sorts labels by score if true or alphabetically                                                   |
 
 For example:
 

--- a/src/codersrank-skills-chart.js
+++ b/src/codersrank-skills-chart.js
@@ -102,6 +102,7 @@ class CodersRankSkillsChart extends HTMLElement {
       'skills',
       'active-skills',
       'show-other-skills',
+      'sort-by-score',
     ];
   }
 
@@ -257,6 +258,20 @@ class CodersRankSkillsChart extends HTMLElement {
     this.setAttribute('branding', value);
   }
 
+  get sortByScore() {
+    const sortByScore = this.getAttribute('sort-by-score');
+    if (sortByScore === '' || sortByScore === 'true') return true;
+    return false;
+  }
+
+  set sortByScore(value) {
+    this.setAttribute('sort-by-score', value);
+  }
+
+  set ['sort-by-score'](value) {
+    this.setAttribute('sort-by-score', value);
+  }
+
   render() {
     const {
       username,
@@ -270,6 +285,7 @@ class CodersRankSkillsChart extends HTMLElement {
       legend,
       labels,
       branding,
+      sortByScore,
 
       hiddenDatasets,
       highlightedDatasetLabel,
@@ -285,6 +301,7 @@ class CodersRankSkillsChart extends HTMLElement {
       legend,
       labels,
       branding,
+      sortByScore,
 
       hiddenDatasets,
       highlightedDatasetLabel,
@@ -324,7 +341,12 @@ class CodersRankSkillsChart extends HTMLElement {
     fetchData(username, id)
       .then((data) => {
         this.emitData(data);
-        this.data = getChartData(data.scores, this.displaySkills, this.showOtherSkills);
+        this.data = getChartData(
+          data.scores,
+          this.displaySkills,
+          this.showOtherSkills,
+          this.sortByScore,
+        );
         if (this.activeSkills && this.activeSkills.length && !this.activeSkillsSet) {
           this.hiddenDatasets = this.data.datasets
             .map((d) => d.label)

--- a/src/shared/get-chart-data.js
+++ b/src/shared/get-chart-data.js
@@ -63,7 +63,7 @@ export const getChartData = (
 
   if (sortByScore) {
     datasets.sort((a, b) => {
-      return a.maxScore > b.maxScore ? 1 : -1;
+      return a.maxScore > b.maxScore ? -1 : 1;
     });
   } else {
     datasets.sort((a, b) => {

--- a/src/shared/get-chart-data.js
+++ b/src/shared/get-chart-data.js
@@ -1,6 +1,11 @@
 import { getColor } from './get-color';
 
-export const getChartData = (data = [], displaySkills = [], showOtherSkills = false) => {
+export const getChartData = (
+  data = [],
+  displaySkills = [],
+  showOtherSkills = false,
+  sortByScore = false,
+) => {
   const scoresData = [...data];
 
   const languagesList = [];
@@ -21,16 +26,19 @@ export const getChartData = (data = [], displaySkills = [], showOtherSkills = fa
   const labels = scoresData.map((score) => score.date);
   const datasets = languagesList.map((language) => {
     const values = [];
+    let maxScore = 0;
     scoresData.forEach((score) => {
       const languageData = score.languages.filter(
         (langData) => langData.language === language,
       )[0];
+      if (languageData && languageData.score > maxScore) maxScore = languageData.score;
       values.push(languageData ? languageData.score : 0);
     });
     return {
       label: language,
       color: getColor(language),
       values,
+      maxScore,
     };
   });
 
@@ -53,9 +61,15 @@ export const getChartData = (data = [], displaySkills = [], showOtherSkills = fa
     };
   }
 
-  datasets.sort((a, b) => {
-    return a.label > b.label ? 1 : -1;
-  });
+  if (sortByScore) {
+    datasets.sort((a, b) => {
+      return a.maxScore > b.maxScore ? 1 : -1;
+    });
+  } else {
+    datasets.sort((a, b) => {
+      return a.label > b.label ? 1 : -1;
+    });
+  }
 
   if (otherDataset) {
     datasets.push(otherDataset);


### PR DESCRIPTION
Alphabetical order doesn't allow to distinct user's primary languages from minor ones
This optional `sort-by-score` attribute should display primary languages first

I can't test this due to #9 